### PR TITLE
Remove Hera-specific CSS styling

### DIFF
--- a/data/styles/global.css
+++ b/data/styles/global.css
@@ -18,12 +18,6 @@
 
 @define-color color_primary alpha (shade (@accent_color, 1.0), 0.5);
 
-/* elementary OS 5 styling */
-@define-color colorPrimary @GRAPE_700;
-@define-color colorAccent @GRAPE_500;
-@define-color textColorPrimary shade (white, 0.9);
-@define-color textColorPrimaryShadow alpha (shade (@colorPrimary, 0.5), 0.6);
-
 .result-label {
     font-size: 7em;
     font-weight: 600;


### PR DESCRIPTION
Hera-specific CSS fallback won't be needed due to switching to Flatpak