### PR TITLE
Add finish-arg to migrate Dconf settings

### DIFF
--- a/com.github.zelikos.rannum.yml
+++ b/com.github.zelikos.rannum.yml
@@ -12,6 +12,8 @@ finish-args:
   - '--socket=wayland'
   # For prefers-color-scheme to work
   - '--system-talk-name=org.freedesktop.Accounts'
+  # To migrate dconf settings from an existing, non-Flatpak install
+  - '--metadata=X-DConf=migrate-path=/com/github/zelikos/rannum/'
 
 modules:
   - name: rannum


### PR DESCRIPTION
Needed to migrate Dconf settings from a non-Flatpak installation, i.e. upgrading from the deb package in Hera to the Flatpak release.