### PR TITLE
Change 'Clear History' shortcut

### DIFF
--- a/data/com.github.zelikos.rannum.appdata.xml.in
+++ b/data/com.github.zelikos.rannum.appdata.xml.in
@@ -19,7 +19,7 @@
       <li>Use Ctrl+1, 2, or 3 to select the first, second, or third dice option</li>
       <li>Hit Ctrl+4 to select the custom die option and focus the number entry when the menu is visible</li>
       <li>Toggle the roll history pane with Ctrl+H</li>
-      <li>Clear roll history with Alt+C</li>
+      <li>Clear roll history with Ctrl+L</li>
     </ul>
   </description>
   <screenshots>

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -175,8 +175,8 @@ public class Rollit.MainWindow : Hdy.Window {
         );
 
         accel_group.connect (
-            Gdk.Key.C,
-            Gdk.ModifierType.MOD1_MASK, // TODO: Replace with ALT_MASK for GTK4
+            Gdk.Key.L,
+            Gdk.ModifierType.CONTROL_MASK,
             Gtk.AccelFlags.VISIBLE | Gtk.AccelFlags.LOCKED,
             () => {
                 roll_history.clear_button.clicked ();


### PR DESCRIPTION
Fixes #57 

Changed the 'Clear History' shortcut from Alt+C to Ctrl+L:
- Better consistency with the other keyboard shortcuts
- Consistent with a common shortcut for clearing terminals (such as elementary's Terminal)