### PR TITLE
Refactors

### DIFF
--- a/data/com.github.zelikos.rannum.gschema.xml
+++ b/data/com.github.zelikos.rannum.gschema.xml
@@ -7,7 +7,7 @@
       <description>Most recent window position (x, y)</description>
     </key>
     <key name="window-size" type="(ii)">
-      <default>(320, 260)</default>
+      <default>(290, 250)</default>
       <summary>Window size</summary>
       <description>Most recent window size (width, height)</description>
     </key>

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -49,7 +49,7 @@ public class Rollit.MainWindow : Hdy.Window {
         };
 
         history_button = new Gtk.Button.from_icon_name ("document-open-recent-symbolic", Gtk.IconSize.MENU) {
-            tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl>H"}, _("Roll History"))
+            tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl>H"}, _("Roll history"))
         };
 
         header.pack_end (history_button);

--- a/src/Widgets/Buttons/PreviousRoll.vala
+++ b/src/Widgets/Buttons/PreviousRoll.vala
@@ -54,7 +54,7 @@ public class Rollit.PreviousRoll : Gtk.ListBoxRow {
 
         var button = new Gtk.Button () {
             margin = 6,
-            tooltip_markup = _("Copy value to clipboard")
+            tooltip_markup = _("Copy result to clipboard")
         };
 
         button.add (stack);

--- a/src/Widgets/Buttons/PreviousRoll.vala
+++ b/src/Widgets/Buttons/PreviousRoll.vala
@@ -16,7 +16,9 @@
  * Authored by Patrick Csikos <zelikos@pm.me>
  */
 
- public class Rollit.PreviousRoll : Gtk.ListBoxRow {
+public class Rollit.PreviousRoll : Gtk.ListBoxRow {
+
+    public signal void copied ();
 
     private Gtk.Image copy_icon;
     private uint timeout_id;
@@ -24,30 +26,18 @@
     public string roll_label { get; construct set; }
     public Gtk.Label roll_amount { get; set; }
 
-    public PreviousRoll () {
-        Object (
-            roll_label: "0"
-        );
-    }
-
-    public PreviousRoll.with_num (int roll) {
+    public PreviousRoll (int roll) {
         Object (
             roll_label: roll.to_string()
         );
     }
 
     construct {
-        roll_amount = new Gtk.Label (roll_label) {
-            halign = START,
-            valign = CENTER
-        };
+        roll_amount = new Gtk.Label (roll_label);
 
-        copy_icon = new Gtk.Image.from_icon_name ("edit-copy-symbolic", Gtk.IconSize.SMALL_TOOLBAR) {
-            halign = END,
-            valign = CENTER
-        };
+        copy_icon = new Gtk.Image.from_icon_name ("edit-copy-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
 
-        var button_layout = new Gtk.Box (HORIZONTAL, 32);
+        var button_layout = new Gtk.Box (HORIZONTAL, 12);
         button_layout.pack_start (roll_amount);
         button_layout.pack_end (copy_icon);
 
@@ -63,7 +53,8 @@
         stack.visible_child_name = "button-box";
 
         var button = new Gtk.Button () {
-            margin = 6
+            margin = 6,
+            tooltip_markup = _("Copy value to clipboard")
         };
 
         button.add (stack);
@@ -71,10 +62,8 @@
         add (button);
 
         button.clicked.connect ( () => {
-            var cb = Gtk.Clipboard.get (Gdk.Atom.NONE);
-            cb.set_text (roll_amount.label, -1);
-
             uint duration = 1000;
+            copy_to_clipboard (roll_label);
 
             stack.visible_child_name = "copied";
             timeout_id = GLib.Timeout.add (duration, () => {
@@ -85,7 +74,13 @@
         });
 
         activate.connect ( () => {
-            button.clicked();
+            button.clicked ();
         });
+    }
+
+    private void copy_to_clipboard (string roll) {
+        var cb = Gtk.Clipboard.get (Gdk.Atom.NONE);
+        cb.set_text (roll, -1);
+        copied ();
     }
  }

--- a/src/Widgets/Buttons/PreviousRoll.vala
+++ b/src/Widgets/Buttons/PreviousRoll.vala
@@ -54,7 +54,7 @@ public class Rollit.PreviousRoll : Gtk.ListBoxRow {
 
         var button = new Gtk.Button () {
             margin = 6,
-            tooltip_markup = _("Copy result to clipboard")
+            tooltip_text = _("Copy result to clipboard")
         };
 
         button.add (stack);

--- a/src/Widgets/Menu.vala
+++ b/src/Widgets/Menu.vala
@@ -94,7 +94,7 @@ public class Rollit.Menu : Gtk.MenuButton {
         popover = menu_popover;
 
         label = max_roll.to_string();
-        tooltip_text = _("Dice Settings");
+        tooltip_text = _("Dice settings");
         tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl>D"}, tooltip_text);
 
         six_sided.clicked.connect ( () => {

--- a/src/Widgets/RollHistory.vala
+++ b/src/Widgets/RollHistory.vala
@@ -47,7 +47,7 @@ public class Rollit.RollHistory : Gtk.Grid {
         bottom_row.margin = 6;
 
         clear_button = new Gtk.Button () {
-            tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl>L"}, _("Clear History")),
+            tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl>L"}, _("Clear history")),
             sensitive = false
         };
         clear_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);

--- a/src/Widgets/RollHistory.vala
+++ b/src/Widgets/RollHistory.vala
@@ -26,18 +26,22 @@ public class Rollit.RollHistory : Gtk.Grid {
 
     construct {
         previous_rolls_box = new Gtk.ListBox () {
+            activate_on_single_click = true,
+            visible = true
+        };
+
+        scroll_box = new Gtk.ScrolledWindow (null, null) {
+            hscrollbar_policy = NEVER,
+            propagate_natural_height = true,
             hexpand = true,
             vexpand = true
         };
-
-        scroll_box = new Gtk.ScrolledWindow (null, null);
-        scroll_box.hscrollbar_policy = NEVER;
         scroll_box.add (previous_rolls_box);
 
         var clear_text = new Gtk.Label (_("Clear"));
         var clear_icon = new Gtk.Image.from_icon_name ("edit-clear-all-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
 
-        var bottom_row = new Gtk.Box (HORIZONTAL, 32);
+        var bottom_row = new Gtk.Box (HORIZONTAL, 12);
         bottom_row.pack_start (clear_text);
         bottom_row.pack_end (clear_icon);
         bottom_row.margin = 6;
@@ -67,7 +71,7 @@ public class Rollit.RollHistory : Gtk.Grid {
     }
 
     public void add_roll (int roll) {
-        var new_roll = new Rollit.PreviousRoll.with_num (roll);
+        var new_roll = new Rollit.PreviousRoll (roll);
 
         previous_rolls_list.append (new_roll);
         previous_rolls_box.prepend (new_roll);


### PR DESCRIPTION
PreviousRoll:
- Reduce to one constructor; no reason to make an instance of PreviousRoll without passing in an integer, so that's just the default constructor now
- Add 'copied' signal, as I may switch to using a toast for confirmation that the value was copied instead of the current implementation of a stack within a button
- Added a tooltip to copy button
- Moved clipboard logic to separate method

General:
- Adjustments to alignment and widget spacing
- Make sure all tooltips throughout the app are in sentence case