### PR TITLE
Flatpak: Remove accountservice sandbox hole

### DIFF
--- a/com.github.zelikos.rannum.yml
+++ b/com.github.zelikos.rannum.yml
@@ -10,8 +10,6 @@ finish-args:
   - '--share=ipc'
   - '--socket=fallback-x11'
   - '--socket=wayland'
-  # For prefers-color-scheme to work
-  - '--system-talk-name=org.freedesktop.Accounts'
   # To migrate dconf settings from an existing, non-Flatpak install
   - '--metadata=X-DConf=migrate-path=/com/github/zelikos/rannum/'
 


### PR DESCRIPTION
No longer needed thanks to the new settings portal