### PR TITLE
chore: GNOME 50 updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block"
@@ -31,9 +31,9 @@ checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "cairo-rs"
-version = "0.20.7"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae50b5510d86cf96ac2370e66d8dc960882f3df179d6a5a1e52bd94a1416c0f7"
+checksum = "5cc8d9aa793480744cd9a0524fef1a2e197d9eaa0f739cde19d16aba530dcb95"
 dependencies = [
  "bitflags",
  "cairo-sys-rs",
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-sys-rs"
-version = "0.20.7"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f18b6bb8e43c7eb0f2aac7976afe0c61b6f5fc2ab7bc4c139537ea56c92290df"
+checksum = "f8b4985713047f5faee02b8db6a6ef32bbb50269ff53c1aee716d1d195b76d54"
 dependencies = [
  "glib-sys",
  "libc",
@@ -92,9 +92,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "field-offset"
@@ -171,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "gdk-pixbuf"
-version = "0.20.9"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7563afd6ff0a221edfbb70a78add5075b8d9cb48e637a40a24c3ece3fea414d0"
+checksum = "25f420376dbee041b2db374ce4573892a36222bb3f6c0c43e24f0d67eae9b646"
 dependencies = [
  "gdk-pixbuf-sys",
  "gio",
@@ -183,9 +183,9 @@ dependencies = [
 
 [[package]]
 name = "gdk-pixbuf-sys"
-version = "0.20.7"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67f2587c9202bf997476bbba6aaed4f78a11538a2567df002a5f57f5331d0b5c"
+checksum = "48f31b37b1fc4b48b54f6b91b7ef04c18e00b4585d98359dd7b998774bbd91fb"
 dependencies = [
  "gio-sys",
  "glib-sys",
@@ -196,9 +196,9 @@ dependencies = [
 
 [[package]]
 name = "gdk4"
-version = "0.9.6"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850c9d9c1aecd1a3eb14fadc1cdb0ac0a2298037e116264c7473e1740a32d60"
+checksum = "fd42fdbbf48612c6e8f47c65fb92d2e8f39c25aecd6af047e83897c1a22d2a4e"
 dependencies = [
  "cairo-rs",
  "gdk-pixbuf",
@@ -211,9 +211,9 @@ dependencies = [
 
 [[package]]
 name = "gdk4-sys"
-version = "0.9.6"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f6eb95798e2b46f279cf59005daf297d5b69555428f185650d71974a910473a"
+checksum = "9d974ac4f15e67472c3a9728daf612590b4a5762a4b33f0edd298df0b80d043c"
 dependencies = [
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
@@ -228,9 +228,9 @@ dependencies = [
 
 [[package]]
 name = "gettext-rs"
-version = "0.7.2"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44e92f7dc08430aca7ed55de161253a22276dfd69c5526e5c5e95d1f7cf338a"
+checksum = "5d5857dc1b7f0fee86961de833f434e29494d72af102ce5355738c0664222bdf"
 dependencies = [
  "gettext-sys",
  "locale_config",
@@ -248,9 +248,9 @@ dependencies = [
 
 [[package]]
 name = "gio"
-version = "0.20.9"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4f00c70f8029d84ea7572dd0e1aaa79e5329667b4c17f329d79ffb1e6277487"
+checksum = "401b600a9795c46ff45890146968b712c96ce4e9393798804133e137bd81d89c"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -265,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "gio-sys"
-version = "0.20.9"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "160eb5250a26998c3e1b54e6a3d4ea15c6c7762a6062a19a7b63eff6e2b33f9e"
+checksum = "64729ba2772c080448f9f966dba8f4456beeb100d8c28a865ef8a0f2ef4987e1"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -278,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "glib"
-version = "0.20.9"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707b819af8059ee5395a2de9f2317d87a53dbad8846a2f089f0bb44703f37686"
+checksum = "a1b7df55594e0e787d1560e23f7e12d7360d0b22e7b7c228ec2488b9e59b1b6b"
 dependencies = [
  "bitflags",
  "futures-channel",
@@ -299,12 +299,11 @@ dependencies = [
 
 [[package]]
 name = "glib-macros"
-version = "0.20.7"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "715601f8f02e71baef9c1f94a657a9a77c192aea6097cf9ae7e5e177cd8cde68"
+checksum = "bda575994e3689b1bc12f89c3df621ead46ff292623b76b4710a3a5b79be54bb"
 dependencies = [
  "heck",
- "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
@@ -312,9 +311,9 @@ dependencies = [
 
 [[package]]
 name = "glib-sys"
-version = "0.20.9"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8928869a44cfdd1fccb17d6746e4ff82c8f82e41ce705aa026a52ca8dc3aefb"
+checksum = "1eb23a616a3dbc7fc15bbd26f58756ff0b04c8a894df3f0680cd21011db6a642"
 dependencies = [
  "libc",
  "system-deps",
@@ -322,9 +321,9 @@ dependencies = [
 
 [[package]]
 name = "gobject-sys"
-version = "0.20.9"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c773a3cb38a419ad9c26c81d177d96b4b08980e8bdbbf32dace883e96e96e7e3"
+checksum = "18eda93f09d3778f38255b231b17ef67195013a592c91624a4daf8bead875565"
 dependencies = [
  "glib-sys",
  "libc",
@@ -333,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "graphene-rs"
-version = "0.20.9"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cbc5911bfb32d68dcfa92c9510c462696c2f715548fcd7f3f1be424c739de19"
+checksum = "c7d1b7881f96869f49808b6adfe906a93a57a34204952253444d68c3208d71f1"
 dependencies = [
  "glib",
  "graphene-sys",
@@ -344,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "graphene-sys"
-version = "0.20.7"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a68d39515bf340e879b72cecd4a25c1332557757ada6e8aba8654b4b81d23a"
+checksum = "517f062f3fd6b7fd3e57a3f038a74b3c23ca32f51199ff028aa704609943f79c"
 dependencies = [
  "glib-sys",
  "libc",
@@ -356,9 +355,9 @@ dependencies = [
 
 [[package]]
 name = "gsk4"
-version = "0.9.6"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61f5e72f931c8c9f65fbfc89fe0ddc7746f147f822f127a53a9854666ac1f855"
+checksum = "53c912dfcbd28acace5fc99c40bb9f25e1dcb73efb1f2608327f66a99acdcb62"
 dependencies = [
  "cairo-rs",
  "gdk4",
@@ -371,9 +370,9 @@ dependencies = [
 
 [[package]]
 name = "gsk4-sys"
-version = "0.9.6"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755059de55fa6f85a46bde8caf03e2184c96bfda1f6206163c72fb0ea12436dc"
+checksum = "d7d54bbc7a9d8b6ffe4f0c95eede15ccfb365c8bf521275abe6bcfb57b18fb8a"
 dependencies = [
  "cairo-sys-rs",
  "gdk4-sys",
@@ -387,9 +386,9 @@ dependencies = [
 
 [[package]]
 name = "gtk4"
-version = "0.9.6"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1c491051f030994fd0cde6f3c44f3f5640210308cff1298c7673c47408091d"
+checksum = "25d47a7ca9ec6f50b5ace32eaaf11fe152c9bbc4f780a35e42c9b7fc5b046f9c"
 dependencies = [
  "cairo-rs",
  "field-offset",
@@ -408,9 +407,9 @@ dependencies = [
 
 [[package]]
 name = "gtk4-macros"
-version = "0.9.5"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed1786c4703dd196baf7e103525ce0cf579b3a63a0570fe653b7ee6bac33999"
+checksum = "3581b242ba62fdff122ebb626ea641582ec326031622bd19d60f85029c804a87"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -420,9 +419,9 @@ dependencies = [
 
 [[package]]
 name = "gtk4-sys"
-version = "0.9.6"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41e03b01e54d77c310e1d98647d73f996d04b2f29b9121fe493ea525a7ec03d6"
+checksum = "5a25bd07084651c77bb6e7bce7d4cea8d9f98d210acee473e400a9106bc0ce50"
 dependencies = [
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
@@ -490,9 +489,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libadwaita"
-version = "0.7.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500135d29c16aabf67baafd3e7741d48e8b8978ca98bac39e589165c8dc78191"
+checksum = "bc0da4e27b20d3e71f830e5b0f0188d22c257986bf421c02cfde777fe07932a4"
 dependencies = [
  "gdk4",
  "gio",
@@ -505,9 +504,9 @@ dependencies = [
 
 [[package]]
 name = "libadwaita-sys"
-version = "0.7.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6680988058c2558baf3f548a370e4e78da3bf7f08469daa822ac414842c912db"
+checksum = "aaee067051c5d3c058d050d167688b80b67de1950cfca77730549aa761fc5d7d"
 dependencies = [
  "gdk4-sys",
  "gio-sys",
@@ -540,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.26"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "malloc_buf"
@@ -555,9 +554,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memoffset"
@@ -599,15 +598,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.1"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "pango"
-version = "0.20.9"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1f5dc1b8cf9bc08bfc0843a04ee0fa2e78f1e1fa4b126844a383af4f25f0ec"
+checksum = "4804fb6018c6604eac198f0f897320d3696c9af7983cde056f07cef93cac9202"
 dependencies = [
  "gio",
  "glib",
@@ -617,9 +616,9 @@ dependencies = [
 
 [[package]]
 name = "pango-sys"
-version = "0.20.9"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dbb9b751673bd8fe49eb78620547973a1e719ed431372122b20abd12445bab5"
+checksum = "bbd111a20ca90fedf03e09c59783c679c00900f1d8491cca5399f5e33609d5d6"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -684,9 +683,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -696,9 +695,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -788,15 +787,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,29 +7,29 @@ edition = "2021"
 lto = true
 
 [dependencies]
-once_cell = "1.21.1"
-libadwaita-sys = "0.7.2"
-log = "0.4.26"
+once_cell = "1.21.4"
+libadwaita-sys = "0.9.1"
+log = "0.4.29"
 pretty_env_logger = "0.5.0"
 # random-number = "0.1.8"
-fastrand = "2.3.0"
-regex = "1.11.1"
+fastrand = "2.4.1"
+regex = "1.12.3"
 
 [dependencies.gtk]
 package = "gtk4"
-version = "0.9.6"
-features = ["v4_18"]
+version = "0.11.2"
+features = ["gnome_50"]
 
 [dependencies.gio]
 package = "gio"
-version = "0.20.9"
-features = ["v2_84"]
+version = "0.22.5"
+features = ["v2_88"]
 
 [dependencies.adw]
 package = "libadwaita"
-version = "0.7.2"
-features = ["v1_7"]
+version = "0.9.1"
+features = ["v1_9"]
 
 [dependencies.gettext-rs]
-version = "0.7.2"
+version = "0.7.7"
 features = ["gettext-system"]

--- a/build-aux/flatpak/dev.zelikos.rollit.Devel.json
+++ b/build-aux/flatpak/dev.zelikos.rollit.Devel.json
@@ -24,30 +24,7 @@
             "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUSTFLAGS": "-C link-arg=-fuse-ld=/usr/lib/sdk/rust-stable/bin/mold"
         }
     },
-    "cleanup": [
-        "/include",
-        "/lib/pkgconfig",
-        "/man",
-        "/share/doc",
-        "/share/gtk-doc",
-        "/share/man",
-        "/share/pkgconfig",
-        "*.la",
-        "*.a"
-    ],
     "modules": [
-        {
-            "name": "blueprint-compiler",
-            "buildsystem": "meson",
-            "cleanup": ["*"],
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler",
-                    "tag": "v0.16.0"
-                }
-            ]
-        },
         {
             "name": "rollit",
             "buildsystem": "meson",

--- a/build-aux/flatpak/dev.zelikos.rollit.Devel.json
+++ b/build-aux/flatpak/dev.zelikos.rollit.Devel.json
@@ -1,9 +1,9 @@
 {
     "id": "dev.zelikos.rollit.Devel",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "48",
+    "runtime-version": "50",
     "sdk": "org.gnome.Sdk",
-    "sdk-extensions": ["org.freedesktop.Sdk.Extension.rust-stable", "org.freedesktop.Sdk.Extension.llvm20"],
+    "sdk-extensions": ["org.freedesktop.Sdk.Extension.rust-stable", "org.freedesktop.Sdk.Extension.llvm22"],
     "command": "rollit",
     "finish-args": [
         "--share=ipc",
@@ -14,7 +14,7 @@
         "--env=RUST_LOG=rollit=debug"
     ],
     "build-options": {
-        "append-path": "/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/llvm20/bin",
+        "append-path": "/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/llvm22/bin",
         "build-args": ["--share=network"],
         "env": {
             "CARGO_REGISTRIES_CRATES_IO_PROTOCOL": "sparse",

--- a/data/meson.build
+++ b/data/meson.build
@@ -72,7 +72,7 @@ endif
 blueprints = custom_target('blueprints',
   input: files(
     'ui/dialogs/dice-chooser.blp',
-    'ui/dialogs/help-overlay.blp',
+    'ui/dialogs/shortcuts-dialog.blp',
     'ui/widgets/history-row.blp',
     'ui/widgets/history-pane.blp',
     'ui/widgets/main-view.blp',

--- a/data/rollit.gresource.xml.in
+++ b/data/rollit.gresource.xml.in
@@ -2,7 +2,7 @@
 <gresources>
   <gresource prefix="/dev/zelikos/rollit">
     <file alias="@app-id@.metainfo.xml" preprocess="xml-stripblanks">@app-id@.metainfo.xml</file>
-    <file alias="gtk/help-overlay.ui">ui/dialogs/help-overlay.ui</file>
+    <file alias="shortcuts-dialog.ui">ui/dialogs/shortcuts-dialog.ui</file>
     <file>ui/dialogs/dice-chooser.ui</file>
     <file>ui/widgets/history-row.ui</file>
     <file>ui/widgets/history-pane.ui</file>

--- a/data/ui/dialogs/shortcuts-dialog.blp
+++ b/data/ui/dialogs/shortcuts-dialog.blp
@@ -1,54 +1,49 @@
 using Gtk 4.0;
+using Adw 1;
 
-ShortcutsWindow help_overlay {
-  modal: true;
+Adw.ShortcutsDialog shortcuts_dialog {
 
-  ShortcutsSection {
-    section-name: "shortcuts";
-    max-height: 10;
+  Adw.ShortcutsSection {
+    title: "General";
 
-    ShortcutsGroup {
-      title: C_("shortcut window", "General");
-
-      ShortcutsShortcut {
+      Adw.ShortcutsItem {
         title: C_("shortcut window", "Roll Dice");
         action-name: "win.roll-dice";
       }
 
-      ShortcutsShortcut {
+      Adw.ShortcutsItem {
         title: C_("shortcut window", "Show Dice Chooser");
         action-name: "win.dice-chooser";
       }
 
-      ShortcutsShortcut {
+      Adw.ShortcutsItem {
         title: C_("shortcut window", "Copy Last Result");
         action-name: "win.copy-latest";
       }
 
-      ShortcutsShortcut {
+      Adw.ShortcutsItem {
         title: C_("shortcut window", "History List");
         action-name: "win.toggle-history";
       }
 
-      ShortcutsShortcut {
+      Adw.ShortcutsItem {
         title: C_("shortcut window", "Clear History");
         action-name: "win.clear-history";
       }
 
-      ShortcutsShortcut {
+      Adw.ShortcutsItem {
         title: C_("shortcut window", "Undo Clear");
         action-name: "win.undo-clear";
       }
 
-      ShortcutsShortcut {
+      Adw.ShortcutsItem {
         title: C_("shortcut window", "Show Shortcuts");
-        action-name: "win.show-help-overlay";
+        action-name: "app.shortcuts";
       }
 
-      ShortcutsShortcut {
+      Adw.ShortcutsItem {
         title: C_("shortcut window", "Quit");
         action-name: "app.quit";
       }
-    }
   }
 }

--- a/data/ui/dialogs/shortcuts-dialog.blp
+++ b/data/ui/dialogs/shortcuts-dialog.blp
@@ -4,46 +4,55 @@ using Adw 1;
 Adw.ShortcutsDialog shortcuts_dialog {
 
   Adw.ShortcutsSection {
-    title: "General";
+    title: "Dice";
 
-      Adw.ShortcutsItem {
-        title: C_("shortcut window", "Roll Dice");
-        action-name: "win.roll-dice";
-      }
+    Adw.ShortcutsItem {
+      title: C_("shortcut window", "Roll Dice");
+      action-name: "win.roll-dice";
+    }
 
-      Adw.ShortcutsItem {
-        title: C_("shortcut window", "Show Dice Chooser");
-        action-name: "win.dice-chooser";
-      }
+    Adw.ShortcutsItem {
+      title: C_("shortcut window", "Show Dice Chooser");
+      action-name: "win.dice-chooser";
+    }
 
-      Adw.ShortcutsItem {
-        title: C_("shortcut window", "Copy Last Result");
-        action-name: "win.copy-latest";
-      }
+    Adw.ShortcutsItem {
+      title: C_("shortcut window", "Copy Last Result");
+      action-name: "win.copy-latest";
+    }
 
-      Adw.ShortcutsItem {
-        title: C_("shortcut window", "History List");
-        action-name: "win.toggle-history";
-      }
+  }
 
-      Adw.ShortcutsItem {
-        title: C_("shortcut window", "Clear History");
-        action-name: "win.clear-history";
-      }
+  Adw.ShortcutsSection {
+    title: "History";
 
-      Adw.ShortcutsItem {
-        title: C_("shortcut window", "Undo Clear");
-        action-name: "win.undo-clear";
-      }
+    Adw.ShortcutsItem {
+      title: C_("shortcut window", "History List");
+      action-name: "win.toggle-history";
+    }
 
-      Adw.ShortcutsItem {
-        title: C_("shortcut window", "Show Shortcuts");
-        action-name: "app.shortcuts";
-      }
+    Adw.ShortcutsItem {
+      title: C_("shortcut window", "Clear History");
+      action-name: "win.clear-history";
+    }
 
-      Adw.ShortcutsItem {
-        title: C_("shortcut window", "Quit");
-        action-name: "app.quit";
-      }
+    Adw.ShortcutsItem {
+      title: C_("shortcut window", "Undo Clear");
+      action-name: "win.undo-clear";
+    }
+  }
+
+  Adw.ShortcutsSection {
+  title: "General";
+
+    Adw.ShortcutsItem {
+      title: C_("shortcut window", "Show Shortcuts");
+      action-name: "app.shortcuts";
+    }
+
+    Adw.ShortcutsItem {
+      title: C_("shortcut window", "Quit");
+      action-name: "app.quit";
+    }
   }
 }

--- a/data/ui/window.blp
+++ b/data/ui/window.blp
@@ -119,7 +119,7 @@ menu primary_menu {
   section {
     item {
       label: _("_Keyboard Shortcuts");
-      action: "win.show-help-overlay";
+      action: "app.shortcuts";
     }
     item {
       label: _("_About Chance");

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -45,8 +45,8 @@ msgid "Result copied"
 msgstr "Resultado copiado"
 
 #: src/widgets/main_view.rs
-msgid "Result copied"
-msgstr "Resultado copiado"
+#msgid "Result copied"
+#msgstr "Resultado copiado"
 
 #: data/ui/window.blp
 msgid "Clear results"
@@ -121,16 +121,16 @@ msgid "Remove dice"
 msgstr "Remover dado"
 
 #: data/dev.zelikos.rollit.desktop.in.in
-msgid "Chance"
-msgstr "Chance"
+#msgid "Chance"
+#msgstr "Chance"
 
 #: data/dev.zelikos.rollit.desktop.in.in
 msgid "Dice Roller App"
 msgstr "Aplicativo de rolagem de dados"
 
 #: data/dev.zelikos.rollit.desktop.in.in
-msgid "Roll the dice"
-msgstr "Role os dados"
+#msgid "Roll the dice"
+#msgstr "Role os dados"
 
 #: data/dev.zelikos.rollit.desktop.in.in
 msgid "Die;Dice;Roll;Random;Number;Rnd;Num;rng;"

--- a/src/application.rs
+++ b/src/application.rs
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2020-2024 Patrick Csikos (https://zelikos.dev)
+/*  Copyright (C) 2020-2026 Patrick Csikos (https://zelikos.dev)
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -119,6 +119,7 @@ impl RollitApplication {
 
     fn setup_accels(&self) {
         self.set_accels_for_action("app.quit", &["<Primary>Q"]);
+        self.set_accels_for_action("app.shortcuts", &["<Primary>question"]);
         self.set_accels_for_action("win.clear-history", &["<Primary>L"]);
         self.set_accels_for_action("win.copy-latest", &["<Primary>C"]);
         self.set_accels_for_action("win.dice-chooser", &["<Primary>comma"]);

--- a/src/application.rs
+++ b/src/application.rs
@@ -136,7 +136,7 @@ impl RollitApplication {
         // Translators: Replace "translator-credits" with your names, one per line
         let translators = &gettext("translator-credits");
 
-        let copyright = "Copyright © 2020-2024 Patrick Csikos";
+        let copyright = "Copyright © 2020-2026 Patrick Csikos";
 
         let about = adw::AboutDialog::from_appdata(
             &format!("/dev/zelikos/rollit/{}.metainfo.xml", APP_ID),

--- a/src/dialogs/dice_chooser.rs
+++ b/src/dialogs/dice_chooser.rs
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2023-2024 Patrick Csikos (https://zelikos.dev)
+/*  Copyright (C) 2023-2026 Patrick Csikos (https://zelikos.dev)
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -100,7 +100,7 @@ mod imp {
 glib::wrapper! {
     pub struct RollitDiceChooser(ObjectSubclass<imp::RollitDiceChooser>)
         @extends gtk::Widget, adw::Dialog,
-        @implements gtk::Accessible, gtk::Actionable;
+        @implements gtk::Accessible, gtk::Actionable, gtk::Buildable, gtk::ConstraintTarget;
 }
 
 impl RollitDiceChooser {

--- a/src/widgets/history_pane.rs
+++ b/src/widgets/history_pane.rs
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2020-2023 Patrick Csikos (https://zelikos.dev)
+/*  Copyright (C) 2020-2026 Patrick Csikos (https://zelikos.dev)
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -74,7 +74,7 @@ mod imp {
 glib::wrapper! {
     pub struct RollitHistoryPane(ObjectSubclass<imp::RollitHistoryPane>)
         @extends gtk::Widget, adw::Bin,
-        @implements gtk::Buildable;
+        @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget;
 }
 
 impl RollitHistoryPane {

--- a/src/widgets/main_view.rs
+++ b/src/widgets/main_view.rs
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2022-2023 Patrick Csikos (https://zelikos.dev)
+/*  Copyright (C) 2022-2026 Patrick Csikos (https://zelikos.dev)
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -81,7 +81,7 @@ mod imp {
 glib::wrapper! {
     pub struct RollitMainView(ObjectSubclass<imp::RollitMainView>)
         @extends gtk::Widget, adw::Bin,
-        @implements gtk::Buildable;
+        @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget;
 }
 
 impl RollitMainView {

--- a/src/widgets/tray_row.rs
+++ b/src/widgets/tray_row.rs
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2023-2024 Patrick Csikos (https://zelikos.dev)
+/*  Copyright (C) 2023-2026 Patrick Csikos (https://zelikos.dev)
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -71,7 +71,7 @@ mod imp {
 glib::wrapper! {
     pub struct RollitTrayRow(ObjectSubclass<imp::RollitTrayRow>)
         @extends gtk::Widget, gtk::ListBoxRow, adw::PreferencesRow, adw::ActionRow,
-        @implements gtk::Accessible, gtk::Actionable, gtk::Buildable;
+        @implements gtk::Accessible, gtk::Actionable, gtk::Buildable, gtk::ConstraintTarget;
 }
 
 impl RollitTrayRow {

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2020-2024 Patrick Csikos (https://zelikos.dev)
+/*  Copyright (C) 2020-2026 Patrick Csikos (https://zelikos.dev)
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -132,7 +132,7 @@ mod imp {
 glib::wrapper! {
     pub struct RollitWindow(ObjectSubclass<imp::RollitWindow>)
         @extends gtk::Widget, gtk::Window, gtk::ApplicationWindow, adw::ApplicationWindow,
-        @implements gio::ActionGroup, gio::ActionMap, gtk::Root;
+        @implements gio::ActionGroup, gio::ActionMap, gtk::Accessible, gtk::Native, gtk::Root, gtk::ShortcutManager, gtk::Buildable, gtk::ConstraintTarget;
 }
 
 #[gtk::template_callbacks]


### PR DESCRIPTION
- Updates the Flatpak manifest to build against the GNOME 50 runtime
- Updates Rust crate dependencies to latest versions
- Adds needed fixes for newer GTK4
- Ports the shortcuts dialog to AdwShortcutsDialog, as GtkShortcutsWindow is deprecated