### PR TITLE
Improve history sidebar contrast and labeling

### DIFF
--- a/data/ui/style.css
+++ b/data/ui/style.css
@@ -3,3 +3,8 @@
   font-size: 6em;
 }
 
+.history-row {
+  background-color: @card_bg_color;
+  border: 1px solid @borders;
+  border-radius: 8px;
+}

--- a/data/ui/widgets/history-row.blp
+++ b/data/ui/widgets/history-row.blp
@@ -7,6 +7,10 @@ template $RollitHistoryRow : Adw.Bin {
   margin-start: 8;
   margin-end: 8;
 
+  styles [
+    "history-row",
+  ]
+
   Box {
     Box {
       orientation: vertical;

--- a/data/ui/window.blp
+++ b/data/ui/window.blp
@@ -22,7 +22,15 @@ template $RollitWindow : Adw.ApplicationWindow {
           Adw.ToolbarView {
             [top]
             Adw.HeaderBar {
-              show-title: false;
+              title-widget:
+                Label {
+                  label: _("History");
+
+                  styles [
+                    "heading",
+                  ]
+                }
+              ;
 
               [start]
               Button {


### PR DESCRIPTION
## Summary

- add a localized `History` heading to the sidebar header
- give history rows a theme-aware card background and border for clearer separation from the pane
- keep the existing list behavior and light/dark theme integration unchanged

Closes #100.

## Validation

- `cargo fmt --all -- --check`
- `blueprint-compiler batch-compile` for all templates
- generated-UI structural assertions for the heading, heading style, and row style class
- `meson compile -C <build-dir>`
- `meson test -C <build-dir> validate-gschema validate-desktop --print-errorlogs`
- `cargo test --all-features` (0 tests)
- `cargo clippy --all-targets --all-features` (passes with 3 pre-existing warnings)
- `cargo doc --no-deps --all-features`
- launched the installed development build on macOS with no GTK/CSS runtime errors

## Notes

The full local Meson test suite reaches the upstream AppStream validation command, but Homebrew AppStream 1.1.3 rejects the project's existing `--nonet` flag. Running validation without that removed flag reports only pre-existing metadata warnings unrelated to this change.